### PR TITLE
feat: add user accounts and authentication for teachers

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
 import os
+import json
+import hashlib
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +23,47 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials
+teachers_file = os.path.join(current_dir, "teachers.json")
+with open(teachers_file) as f:
+    teachers = json.load(f)
+
+# In-memory session store: token -> username
+active_sessions: dict[str, str] = {}
+
+security = HTTPBearer(auto_error=False)
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def verify_password(username: str, password: str) -> bool:
+    if username not in teachers:
+        return False
+    teacher = teachers[username]
+    h = hashlib.pbkdf2_hmac(
+        'sha256',
+        password.encode(),
+        teacher["salt"].encode(),
+        100000
+    ).hex()
+    return secrets.compare_digest(h, teacher["password_hash"])
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str | None:
+    if credentials is None:
+        return None
+    return active_sessions.get(credentials.credentials)
+
+
+def require_teacher(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+    user = get_current_user(credentials)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user
 
 # In-memory activity database
 activities = {
@@ -83,13 +129,40 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/auth/login")
+def login(request: LoginRequest):
+    """Authenticate a teacher and return a session token"""
+    if not verify_password(request.username, request.password):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    token = secrets.token_hex(32)
+    active_sessions[token] = request.username
+    return {"token": token, "username": request.username}
+
+
+@app.post("/auth/logout")
+def logout(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Invalidate the current session token"""
+    if credentials and credentials.credentials in active_sessions:
+        del active_sessions[credentials.credentials]
+    return {"message": "Logged out successfully"}
+
+
+@app.get("/auth/status")
+def auth_status(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    """Check if the current token is valid"""
+    user = get_current_user(credentials)
+    if user:
+        return {"authenticated": True, "username": user}
+    return {"authenticated": False}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, teacher: str = Depends(require_teacher)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +184,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, teacher: str = Depends(require_teacher)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,258 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Auth elements
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authUsername = document.getElementById("auth-username");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+  const loginError = document.getElementById("login-error");
+
+  function getToken() {
+    return localStorage.getItem("auth_token");
+  }
+
+  function getUsername() {
+    return localStorage.getItem("auth_username");
+  }
+
+  function isLoggedIn() {
+    return !!getToken();
+  }
+
+  function updateAuthUI() {
+    if (isLoggedIn()) {
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+      authUsername.textContent = `👤 ${getUsername()}`;
+      authUsername.classList.remove("hidden");
+      signupForm.parentElement.classList.remove("hidden");
+    } else {
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      authUsername.classList.add("hidden");
+      signupForm.parentElement.classList.add("hidden");
+    }
+    fetchActivities();
+  }
+
+  // Login button opens modal
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    loginError.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  cancelLoginBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  // Handle login form submission
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("login-username").value;
+    const password = document.getElementById("login-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      const result = await response.json();
+
+      if (response.ok) {
+        localStorage.setItem("auth_token", result.token);
+        localStorage.setItem("auth_username", result.username);
+        loginModal.classList.add("hidden");
+        updateAuthUI();
+      } else {
+        loginError.textContent = result.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginError.textContent = "Login failed. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", async () => {
+    const token = getToken();
+    if (token) {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    }
+    localStorage.removeItem("auth_token");
+    localStorage.removeItem("auth_username");
+    updateAuthUI();
+  });
+
+  // Function to fetch activities from API
+  async function fetchActivities() {
+    try {
+      const response = await fetch("/activities");
+      const activities = await response.json();
+
+      // Clear loading message
+      activitiesList.innerHTML = "";
+
+      // Populate activities list
+      Object.entries(activities).forEach(([name, details]) => {
+        const activityCard = document.createElement("div");
+        activityCard.className = "activity-card";
+
+        const spotsLeft =
+          details.max_participants - details.participants.length;
+
+        // Only show delete buttons for logged-in teachers
+        const participantsHTML =
+          details.participants.length > 0
+            ? `<div class="participants-section">
+              <h5>Participants:</h5>
+              <ul class="participants-list">
+                ${details.participants
+                  .map(
+                    (email) =>
+                      `<li><span class="participant-email">${email}</span>${
+                        isLoggedIn()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
+                  )
+                  .join("")}
+              </ul>
+            </div>`
+            : `<p><em>No participants yet</em></p>`;
+
+        activityCard.innerHTML = `
+          <h4>${name}</h4>
+          <p>${details.description}</p>
+          <p><strong>Schedule:</strong> ${details.schedule}</p>
+          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-container">
+            ${participantsHTML}
+          </div>
+        `;
+
+        activitiesList.appendChild(activityCard);
+
+        // Add option to select dropdown
+        const option = document.createElement("option");
+        option.value = name;
+        option.textContent = name;
+        activitySelect.appendChild(option);
+      });
+
+      // Add event listeners to delete buttons
+      document.querySelectorAll(".delete-btn").forEach((button) => {
+        button.addEventListener("click", handleUnregister);
+      });
+    } catch (error) {
+      activitiesList.innerHTML =
+        "<p>Failed to load activities. Please try again later.</p>";
+      console.error("Error fetching activities:", error);
+    }
+  }
+
+  // Handle unregister functionality
+  async function handleUnregister(event) {
+    const button = event.target;
+    const activity = button.getAttribute("data-activity");
+    const email = button.getAttribute("data-email");
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(
+          activity
+        )}/unregister?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${getToken()}` },
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+
+        // Refresh activities list to show updated participants
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      // Hide message after 5 seconds
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering:", error);
+    }
+  }
+
+  // Handle form submission
+  signupForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const email = document.getElementById("email").value;
+    const activity = document.getElementById("activity").value;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(
+          activity
+        )}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${getToken()}` },
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        signupForm.reset();
+
+        // Refresh activities list to show updated participants
+        fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      // Hide message after 5 seconds
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to sign up. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error signing up:", error);
+    }
+  });
+
+  // Initialize app
+  updateAuthUI();
+});
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,32 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-widget">
+        <span id="auth-username" class="hidden"></span>
+        <button id="login-btn">🔑 Login</button>
+        <button id="logout-btn" class="hidden">Logout</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-username">Username:</label>
+            <input type="text" id="login-username" required placeholder="username" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required placeholder="password" />
+          </div>
+          <button type="submit">Login</button>
+          <button type="button" id="cancel-login-btn">Cancel</button>
+        </form>
+        <div id="login-error" class="hidden error"></div>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,7 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
@@ -197,4 +198,72 @@ footer {
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+/* Auth widget */
+#auth-widget {
+  position: absolute;
+  top: 15px;
+  right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#auth-widget button {
+  padding: 6px 12px;
+  font-size: 14px;
+}
+
+#auth-username {
+  color: #c5cae9;
+  font-size: 14px;
+}
+
+#logout-btn {
+  background-color: #c62828;
+}
+
+#logout-btn:hover {
+  background-color: #e53935;
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+}
+
+.modal-content button[type="button"] {
+  background-color: #9e9e9e;
+  margin-left: 10px;
+}
+
+.modal-content button[type="button"]:hover {
+  background-color: #757575;
+}
+
+#login-error {
+  margin-top: 12px;
+  padding: 8px;
+  border-radius: 4px;
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "principal": {
+    "salt": "4c783e7edd818edca828caaba3b54748",
+    "password_hash": "45f8eb720abadccaaa88d9178f0a70ac5100fa76508f9427baa03c3fdf43720f"
+  }
+}


### PR DESCRIPTION
## Summary

Implements teacher authentication to prevent students from removing each other from activities (fixes the abuse reported in #5).

## Changes

### Backend (`src/app.py`)
- Load teacher credentials from `teachers.json` at startup (PBKDF2-SHA256 hashed passwords with per-user salt)
- In-memory session store mapping tokens to usernames
- `POST /auth/login` — validates credentials, returns a session token
- `POST /auth/logout` — invalidates the token
- `GET /auth/status` — returns current authentication state
- `POST /activities/{name}/signup` — now requires a valid teacher Bearer token
- `DELETE /activities/{name}/unregister` — now requires a valid teacher Bearer token

### Credentials file (`src/teachers.json`)
- Stores teacher usernames with salted PBKDF2 password hashes
- Default account: username `principal`, password `teacher123`

### Frontend
- **`index.html`**: Login button in header top-right; login modal with username/password form
- **`app.js`**: Token persisted in `localStorage`; sign-up form and ❌ unregister buttons hidden when not logged in; all mutating requests include `Authorization: Bearer` header
- **`styles.css`**: Styles for auth widget, login modal, and logout button

## How to test

1. Open the app — the sign-up form and unregister buttons are not visible
2. Click **🔑 Login**, enter `principal` / `teacher123`
3. Sign-up form and unregister buttons are now visible and functional
4. Click **Logout** — they disappear again

Closes #24
Closes #5